### PR TITLE
Bugfix/nullpointer no erro handler ao buscar status code

### DIFF
--- a/src/main/java/br/edu/utfpr/pb/ext/server/projeto/ProjetoController.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/projeto/ProjetoController.java
@@ -73,8 +73,7 @@ public class ProjetoController extends CrudController<Projeto, ProjetoDTO, Long>
     projeto.setPublicoAlvo(dto.getPublicoAlvo());
     projeto.setVinculadoDisciplina(dto.isVinculadoDisciplina());
     projeto.setRestricaoPublico(dto.getRestricaoPublico());
-    projeto.setEquipeExecutora(
-        usuarios.stream().filter(Optional::isPresent).map(Optional::get).toList());
+    projeto.setEquipeExecutora(usuarios.stream().flatMap(Optional::stream).toList());
     projeto.setStatus(StatusProjeto.EM_ANDAMENTO);
     Projeto projetoResponse = projetoService.save(projeto);
     ProjetoDTO projetoDTO = modelMapper.map(projetoResponse, ProjetoDTO.class);

--- a/src/test/java/br/edu/utfpr/pb/ext/server/error/ErrorHandlerTest.java
+++ b/src/test/java/br/edu/utfpr/pb/ext/server/error/ErrorHandlerTest.java
@@ -61,20 +61,25 @@ class ErrorHandlerTest {
 
   @Test
   @Description("Erro deve retornar o status 500 quando não houver status no atributo")
-  void handleError_WhenStatusDoesNotExistOnAttributes_ShouldReturnApiErrorWithDefaultStatusCode(){
+  void handleError_WhenStatusDoesNotExistOnAttributes_ShouldReturnApiErrorWithDefaultStatusCode() {
     attributes.remove("status");
     ApiError result = errorHandler.handleError(webRequest);
     assertThat(result.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
   }
 
   @Test
+  @Description("Erro deve ser retornado no caso do campo path estar nulo")
+  void handleError_whenPathDoesNotExist_ShouldReturnApiErrorWithAttributes() {
+    attributes.remove("path");
+    ApiError result = errorHandler.handleError(webRequest);
+    assertThat(result.getUrl()).isNull();
+  }
+
+  @Test
   @Description("Erro deve ser retornado no caso do campo mensagem estar nulo")
   void handleError_WhenMessageNotExist_ShouldReturnApiErrorWithAttributes() {
-
     attributes.remove("message");
-
     ApiError result = errorHandler.handleError(webRequest);
-
     assertThat(result.getMessage()).isNull();
   }
 }


### PR DESCRIPTION
# Pull Request

## Descrição
Adição de teste unitário para ErrorHandler

## Checklist
<!-- Marque itens concluídos com um x (sem espaços ao redor) -->
- [x] Meu código segue a convenção de código definida no documento
- [x] Eu revisei o código que estou enviando para o PR
- [x] Eu adicionei Javadoc em funções públicas de negócio ou comentários em lugares necessários
- [x] Minhas mudanças não geraram nenhum warning
- [x] Eu rodei `mvn install` e não gerou erro
- [x] Cobri o código com teste unitário ou de integração
- [x] Não quebrei nenhum teste com minhas mudanças

## Instruções de Teste


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Testes**
  - Adicionado um novo teste para verificar o comportamento do sistema quando o atributo "path" está ausente em erros, garantindo que a URL no objeto de erro da API seja nula.
  - Ajustes de formatação em métodos de teste existentes para maior consistência visual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->