### PR TITLE
PEXT-67 refactor: rename 'nomeCompleto' to 'nome' in DTOs and tests for consistency

### DIFF
--- a/src/main/java/br/edu/utfpr/pb/ext/server/usuario/dto/UsuarioAlunoRequestDTO.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/usuario/dto/UsuarioAlunoRequestDTO.java
@@ -13,7 +13,7 @@ public class UsuarioAlunoRequestDTO {
 
   private Long id;
 
-  @NotNull private String nomeCompleto;
+  @NotNull private String nome;
 
   @NotNull @CPF @UniqueCpf private String cpf;
 

--- a/src/main/java/br/edu/utfpr/pb/ext/server/usuario/dto/UsuarioProjetoDTO.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/usuario/dto/UsuarioProjetoDTO.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class UsuarioProjetoDTO {
   private Long id;
 
-  @NotNull private String nomeCompleto;
+  @NotNull private String nome;
 
   @NotNull @Email(regexp = "^[a-zA-Z0-9._%+-]+@(utfpr\\.edu\\.br)$")
   private String emailInstitucional;

--- a/src/main/java/br/edu/utfpr/pb/ext/server/usuario/dto/UsuarioServidorRequestDTO.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/usuario/dto/UsuarioServidorRequestDTO.java
@@ -12,7 +12,7 @@ public class UsuarioServidorRequestDTO {
 
   private Long id;
 
-  @NotNull private String nomeCompleto;
+  @NotNull private String nome;
 
   @NotNull @CPF @UniqueCpf private String cpf;
 

--- a/src/main/java/br/edu/utfpr/pb/ext/server/usuario/dto/UsuarioServidorResponseDTO.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/usuario/dto/UsuarioServidorResponseDTO.java
@@ -7,7 +7,7 @@ public class UsuarioServidorResponseDTO {
 
   private Long id;
 
-  private String nomeCompleto;
+  private String nome;
 
   private String emailInstitucional;
 

--- a/src/test/java/br/edu/utfpr/pb/ext/server/projeto/ProjetoControllerTest.java
+++ b/src/test/java/br/edu/utfpr/pb/ext/server/projeto/ProjetoControllerTest.java
@@ -37,7 +37,7 @@ class ProjetoControllerTest {
     projetoDTO.setEquipeExecutora(
         List.of(
             UsuarioProjetoDTO.builder()
-                .nomeCompleto("batata")
+                .nome("batata")
                 .emailInstitucional("batata@utfpr.edu.br")
                 .build()));
 

--- a/src/test/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioControllerTest.java
+++ b/src/test/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioControllerTest.java
@@ -172,7 +172,7 @@ class UsuarioControllerTest {
 
   private UsuarioServidorRequestDTO createUsuarioServidorRequestDTO() {
     UsuarioServidorRequestDTO request = new UsuarioServidorRequestDTO();
-    request.setNomeCompleto("teste");
+    request.setNome("teste");
     request.setCpf("29212492002");
     request.setSiape("1234567");
     request.setEmailInstitucional("batata@utfpr.edu.br");
@@ -182,7 +182,7 @@ class UsuarioControllerTest {
 
   private UsuarioAlunoRequestDTO createUsuarioAlunoRequestDTO() {
     UsuarioAlunoRequestDTO request = new UsuarioAlunoRequestDTO();
-    request.setNomeCompleto("teste");
+    request.setNome("teste");
     request.setCpf("29212492002");
     request.setRegistroAcademico("1234567");
     request.setEmailInstitucional("batata@alunos.utfpr.edu.br");


### PR DESCRIPTION
# Pull Request

## Descrição
<!-- Descreva as mudanças feitas no pull request-->

## Checklist
<!-- Marque itens concluídos com um x (sem espaços ao redor) -->
- [ ] Meu código segue a convenção de código definida no documento
- [ ] Eu revisei o código que estou enviando para o PR
- [ ] Eu adicionei Javadoc em funções públicas de negócio ou comentários em lugares necessários
- [ ] Minhas mudanças não geraram nenhum warning
- [ ] Eu rodei `mvn install` e não gerou erro
- [ ] Cobri o código com teste unitário ou de integração
- [ ] Não quebrei nenhum teste com minhas mudanças

## Instruções de Teste
<!-- Como testar o que foi feito, se houver necessidade. Ex: fazer POST /users com os dados "x": "x" no body -->

## Informação Adicional
<!-- Alguma outra coisa de contexto -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refatoração**
  - O campo referente ao nome completo dos usuários foi renomeado de "nomeCompleto" para "nome" em diversas telas e funcionalidades do sistema.

- **Testes**
  - Atualizados os testes automatizados para refletir a alteração do nome do campo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->