### PR TITLE
feat: retornar departamentos no endpoint com segurança e flyway OK

### DIFF
--- a/src/main/java/br/edu/utfpr/pb/ext/server/departamento/Departamento.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/departamento/Departamento.java
@@ -1,0 +1,33 @@
+package br.edu.utfpr.pb.ext.server.departamento;
+
+import br.edu.utfpr.pb.ext.server.generics.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Entidade que representa um Departamento da instituição.
+ * Cada departamento possui uma sigla única e um nome.
+ */
+@Entity
+@Table(name = "tb_departamento") // Nome da tabela no banco de dados
+@Getter
+@Setter
+public class Departamento extends BaseEntity {
+
+  /**
+   * Sigla do departamento (ex: DAINF, DAADM).
+   * Deve ser única e conter no máximo 20 caracteres.
+   */
+  @Column(nullable = false, unique = true, length = 20)
+  private String sigla;
+
+  /**
+   * Nome completo do departamento.
+   * Campo obrigatório.
+   */
+  @Column(nullable = false)
+  private String nome;
+}

--- a/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoController.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoController.java
@@ -1,0 +1,103 @@
+package br.edu.utfpr.pb.ext.server.departamento;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Controller responsável pelos endpoints da entidade Departamento.
+ * Fornece operações de CRUD (Create, Read, Update, Delete).
+ */
+@RestController
+@RequestMapping("/api/departamentos")
+public class DepartamentoController {
+
+  private final DepartamentoService service;
+
+  /**
+   * Construtor com injeção de dependência do serviço de departamento.
+   */
+  public DepartamentoController(DepartamentoService service) {
+    this.service = service;
+  }
+
+  /**
+   * Lista todos os departamentos cadastrados.
+   * @return Lista de DepartamentoDto com status HTTP 200 (OK).
+   */
+  @GetMapping
+  public ResponseEntity<List<DepartamentoDto>> listarTodos() {
+    List<DepartamentoDto> dtos = service.findAll().stream()
+            .map(this::toDto) // Conversão de entidade para DTO
+            .collect(Collectors.toList());
+    return ResponseEntity.ok(dtos);
+  }
+
+  /**
+   * Busca um departamento pelo ID informado na URL.
+   * @param id ID do departamento.
+   * @return DepartamentoDto correspondente com status HTTP 200.
+   */
+  @GetMapping("/{id}")
+  public ResponseEntity<DepartamentoDto> buscarPorId(@PathVariable Long id) {
+    Departamento departamento = service.findOne(id);
+    return ResponseEntity.ok(toDto(departamento));
+  }
+
+  /**
+   * Cria um novo departamento com base no DTO recebido no corpo da requisição.
+   * @param dto DTO com os dados do novo departamento.
+   * @return DepartamentoDto criado com status HTTP 201 (Created).
+   */
+  @PostMapping
+  public ResponseEntity<DepartamentoDto> criar(@RequestBody DepartamentoDto dto) {
+    Departamento salvo = service.save(toEntity(dto));
+    return ResponseEntity.status(201).body(toDto(salvo));
+  }
+
+  /**
+   * Atualiza os dados de um departamento existente.
+   * @param id ID do departamento a ser atualizado.
+   * @param dto DTO com os novos dados.
+   * @return DepartamentoDto atualizado com status HTTP 200, ou 400 se o ID for inconsistente.
+   */
+  @PutMapping("/{id}")
+  public ResponseEntity<DepartamentoDto> atualizar(@PathVariable Long id, @RequestBody DepartamentoDto dto) {
+    if (!id.equals(dto.getId())) {
+      return ResponseEntity.badRequest().build(); // Garante consistência entre URL e corpo da requisição
+    }
+    Departamento atualizado = service.save(toEntity(dto));
+    return ResponseEntity.ok(toDto(atualizado));
+  }
+
+  /**
+   * Exclui um departamento com base no ID fornecido.
+   * @param id ID do departamento a ser excluído.
+   * @return Resposta sem conteúdo (HTTP 204).
+   */
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> excluir(@PathVariable Long id) {
+    service.delete(id);
+    return ResponseEntity.noContent().build();
+  }
+
+  // Conversão auxiliar de entidade para DTO
+  private DepartamentoDto toDto(Departamento entity) {
+    DepartamentoDto dto = new DepartamentoDto();
+    dto.setId(entity.getId());
+    dto.setNome(entity.getNome());
+    dto.setSigla(entity.getSigla());
+    return dto;
+  }
+
+  // Conversão auxiliar de DTO para entidade
+  private Departamento toEntity(DepartamentoDto dto) {
+    Departamento entity = new Departamento();
+    entity.setId(dto.getId());
+    entity.setNome(dto.getNome());
+    entity.setSigla(dto.getSigla());
+    return entity;
+  }
+}

--- a/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoDto.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoDto.java
@@ -1,0 +1,27 @@
+package br.edu.utfpr.pb.ext.server.departamento;
+
+import lombok.Data;
+
+/**
+ * Data Transfer Object (DTO) para a entidade Departamento.
+ * Utilizado para transferência de dados entre as camadas da aplicação,
+ * especialmente entre o backend e o frontend (ou APIs externas).
+ */
+@Data
+public class DepartamentoDto {
+
+  /**
+   * Identificador único do departamento.
+   */
+  private Long id;
+
+  /**
+   * Sigla do departamento (exemplo: DAINF, DAADM).
+   */
+  private String sigla;
+
+  /**
+   * Nome completo do departamento.
+   */
+  private String nome;
+}

--- a/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoRepository.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoRepository.java
@@ -1,0 +1,16 @@
+package br.edu.utfpr.pb.ext.server.departamento;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório JPA para a entidade Departamento.
+ * Fornece operações básicas de persistência, como salvar, buscar, atualizar e deletar.
+ *
+ * A interface JpaRepository já fornece métodos prontos como:
+ * - findById
+ * - findAll
+ * - save
+ * - deleteById
+ * - existsById
+ */
+public interface DepartamentoRepository extends JpaRepository<Departamento, Long> {}

--- a/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoService.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoService.java
@@ -1,0 +1,12 @@
+package br.edu.utfpr.pb.ext.server.departamento;
+
+import br.edu.utfpr.pb.ext.server.generics.ICrudService;
+
+/**
+ * Interface de serviço para operações relacionadas à entidade Departamento.
+ * Estende a interface genérica ICrudService, herdando operações básicas de CRUD.
+ *
+ * Essa interface pode ser expandida futuramente com métodos específicos
+ * relacionados a regras de negócio da entidade Departamento.
+ */
+public interface DepartamentoService extends ICrudService<Departamento, Long> {}

--- a/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoServiceImpl.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoServiceImpl.java
@@ -1,0 +1,36 @@
+package br.edu.utfpr.pb.ext.server.departamento;
+
+import br.edu.utfpr.pb.ext.server.generics.CrudServiceImpl;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementação do serviço de Departamento.
+ * Estende a classe genérica CrudServiceImpl para reaproveitamento de lógica CRUD.
+ * Implementa a interface DepartamentoService para permitir futura expansão de regras de negócio.
+ */
+@Service
+public class DepartamentoServiceImpl extends CrudServiceImpl<Departamento, Long>
+        implements DepartamentoService {
+
+  private final DepartamentoRepository repository;
+
+  /**
+   * Construtor que injeta o repositório específico de Departamento.
+   *
+   * @param repository Repositório JPA para a entidade Departamento.
+   */
+  public DepartamentoServiceImpl(DepartamentoRepository repository) {
+    this.repository = repository;
+  }
+
+  /**
+   * Retorna o repositório específico da entidade para uso na classe genérica.
+   *
+   * @return JpaRepository de Departamento.
+   */
+  @Override
+  protected JpaRepository<Departamento, Long> getRepository() {
+    return repository;
+  }
+}

--- a/src/main/resources/db/migration/V1.2.3__create_tb_departamento.sql
+++ b/src/main/resources/db/migration/V1.2.3__create_tb_departamento.sql
@@ -1,0 +1,70 @@
+CREATE TABLE IF NOT EXISTS tb_departamento (
+                                               id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+                                               sigla VARCHAR(20) NOT NULL UNIQUE,
+    nome VARCHAR(255) NOT NULL
+    );
+
+-- Inserts com proteção para evitar duplicidade
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'CALEM', 'Centro Acadêmico Lingua Estrangeira Moderna'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'CALEM');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'DAADM', 'Departamento de Administração'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'DAADM');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'DAGRO', 'Departamento de Agronomia'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'DAGRO');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'DACOC', 'Departamento Acadêmico de Construção Civil'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'DACOC');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'DACON', 'Departamento de Ciências Contábeis'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'DACON');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'DAELE', 'Departamento de Engenharia Elétrica'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'DAELE');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'DAFIS', 'Departamento de Física'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'DAFIS');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'DAHUM', 'Departamento de Ciências Humanas'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'DAHUM');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'DAINF', 'Departamento de Ciência da Computação'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'DAINF');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'DALET', 'Departamento de Letras'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'DALET');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'DAMAT', 'Departamento de Matemática'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'DAMAT');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'DAMEC', 'Departamento de Engenharia Mecânica'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'DAMEC');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'DAQUI', 'Departamento de Química'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'DAQUI');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'LATO_SENSU', 'Departamento de Pós-Graduação Lato Sensu'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'LATO_SENSU');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'NUAPE', 'Núcleo de Apoio Pedagógico'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'NUAPE');
+
+INSERT INTO tb_departamento (sigla, nome)
+SELECT 'STRICTO', 'Departamento de Pós-Graduação Stricto Sensu'
+    WHERE NOT EXISTS (SELECT 1 FROM tb_departamento WHERE sigla = 'STRICTO');

--- a/src/test/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoControllerTest.java
+++ b/src/test/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoControllerTest.java
@@ -1,0 +1,146 @@
+package br.edu.utfpr.pb.ext.server.departamento;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Testes unitários da camada de controle (controller) para o recurso Departamento.
+ * Verifica o funcionamento correto dos endpoints da API exposta pelo DepartamentoController.
+ */
+class DepartamentoControllerTest {
+
+    private DepartamentoService service;
+    private DepartamentoController controller;
+
+    /**
+     * Configura o mock do serviço e instancia o controller antes de cada teste.
+     */
+    @BeforeEach
+    void setUp() {
+        service = mock(DepartamentoService.class);
+        controller = new DepartamentoController(service);
+    }
+
+    /**
+     * Testa o endpoint GET /api/departamentos
+     * Deve retornar uma lista com todos os departamentos existentes.
+     */
+    @Test
+    void deveListarTodosOsDepartamentos() {
+        Departamento departamento = new Departamento();
+        departamento.setId(1L);
+        departamento.setSigla("DINF");
+        departamento.setNome("Departamento de Informática");
+
+        when(service.findAll()).thenReturn(List.of(departamento));
+
+        ResponseEntity<List<DepartamentoDto>> response = controller.listarTodos();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().size());
+        assertEquals("DINF", response.getBody().get(0).getSigla());
+    }
+
+    /**
+     * Testa o endpoint GET /api/departamentos/{id}
+     * Deve retornar o departamento correspondente ao ID.
+     */
+    @Test
+    void deveBuscarDepartamentoPorId() {
+        Departamento departamento = new Departamento();
+        departamento.setId(1L);
+        departamento.setSigla("DINF");
+        departamento.setNome("Departamento de Informática");
+
+        when(service.findOne(1L)).thenReturn(departamento);
+
+        ResponseEntity<DepartamentoDto> response = controller.buscarPorId(1L);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("DINF", response.getBody().getSigla());
+    }
+
+    /**
+     * Testa o endpoint POST /api/departamentos
+     * Deve criar um novo departamento e retornar status 201 (CREATED).
+     */
+    @Test
+    void deveCriarDepartamento() {
+        DepartamentoDto dto = new DepartamentoDto();
+        dto.setId(1L);
+        dto.setSigla("DQUI");
+        dto.setNome("Departamento de Química");
+
+        Departamento entidade = new Departamento();
+        entidade.setId(1L);
+        entidade.setSigla("DQUI");
+        entidade.setNome("Departamento de Química");
+
+        when(service.save(any(Departamento.class))).thenReturn(entidade);
+
+        ResponseEntity<DepartamentoDto> response = controller.criar(dto);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals("DQUI", response.getBody().getSigla());
+    }
+
+    /**
+     * Testa o endpoint PUT /api/departamentos/{id}
+     * Deve atualizar o departamento correspondente ao ID com sucesso.
+     */
+    @Test
+    void deveAtualizarDepartamento() {
+        DepartamentoDto dto = new DepartamentoDto();
+        dto.setId(2L);
+        dto.setSigla("DMEC");
+        dto.setNome("Departamento de Mecânica");
+
+        Departamento atualizado = new Departamento();
+        atualizado.setId(2L);
+        atualizado.setSigla("DMEC");
+        atualizado.setNome("Departamento de Mecânica");
+
+        when(service.save(any(Departamento.class))).thenReturn(atualizado);
+
+        ResponseEntity<DepartamentoDto> response = controller.atualizar(2L, dto);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("DMEC", response.getBody().getSigla());
+    }
+
+    /**
+     * Testa o endpoint PUT /api/departamentos/{id}
+     * Não deve permitir a atualização se o ID da URL for diferente do ID do corpo.
+     */
+    @Test
+    void naoDeveAtualizarComIdDivergente() {
+        DepartamentoDto dto = new DepartamentoDto();
+        dto.setId(99L); // diferente do ID informado na URL
+
+        ResponseEntity<DepartamentoDto> response = controller.atualizar(1L, dto);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+    /**
+     * Testa o endpoint DELETE /api/departamentos/{id}
+     * Deve excluir o departamento correspondente ao ID e retornar status 204 (NO CONTENT).
+     */
+    @Test
+    void deveExcluirDepartamento() {
+        doNothing().when(service).delete(1L);
+
+        ResponseEntity<Void> response = controller.excluir(1L);
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(service, times(1)).delete(1L);
+    }
+}

--- a/src/test/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoServiceTest.java
+++ b/src/test/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoServiceTest.java
@@ -1,0 +1,103 @@
+package br.edu.utfpr.pb.ext.server.departamento;
+
+import br.edu.utfpr.pb.ext.server.generics.ICrudService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Testes unitários para a classe DepartamentoServiceImpl.
+ * Verifica o funcionamento básico dos métodos herdados da ICrudService.
+ */
+public class DepartamentoServiceTest {
+
+    private DepartamentoRepository departamentoRepository;
+    private ICrudService<Departamento, Long> service;
+
+    /**
+     * Inicializa o mock do repositório e a instância do serviço antes de cada teste.
+     */
+    @BeforeEach
+    void setUp() {
+        departamentoRepository = mock(DepartamentoRepository.class);
+        service = new DepartamentoServiceImpl(departamentoRepository);
+    }
+
+    /**
+     * Testa se o método findAll() retorna corretamente todos os departamentos simulados.
+     */
+    @Test
+    void shouldFindAllDepartamentos() {
+        List<Departamento> mockList = Arrays.asList(
+                createDepartamento(1L, "DAINF", "Departamento de Computação"),
+                createDepartamento(2L, "DAMAT", "Departamento de Matemática")
+        );
+
+        when(departamentoRepository.findAll()).thenReturn(mockList);
+
+        List<Departamento> result = service.findAll();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getSigla()).isEqualTo("DAINF");
+    }
+
+    /**
+     * Testa se o método findOne() retorna corretamente um departamento pelo ID.
+     */
+    @Test
+    void shouldFindById() {
+        Departamento departamento = createDepartamento(1L, "DAINF", "Computação");
+        when(departamentoRepository.findById(1L)).thenReturn(Optional.of(departamento));
+
+        Departamento result = service.findOne(1L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getSigla()).isEqualTo("DAINF");
+    }
+
+    /**
+     * Testa se o método save() persiste um novo departamento e retorna a entidade salva.
+     */
+    @Test
+    void shouldSaveDepartamento() {
+        Departamento departamento = createDepartamento(null, "DAINF", "Computação");
+        Departamento saved = createDepartamento(1L, "DAINF", "Computação");
+
+        when(departamentoRepository.save(departamento)).thenReturn(saved);
+
+        Departamento result = service.save(departamento);
+
+        assertThat(result.getId()).isEqualTo(1L);
+    }
+
+    /**
+     * Testa se o método delete() chama corretamente a exclusão do repositório por ID.
+     */
+    @Test
+    void shouldDeleteById() {
+        service.delete(1L);
+        verify(departamentoRepository, times(1)).deleteById(1L);
+    }
+
+    /**
+     * Método auxiliar para criar instâncias de Departamento durante os testes.
+     *
+     * @param id    ID do departamento.
+     * @param sigla Sigla do departamento.
+     * @param nome  Nome completo do departamento.
+     * @return Objeto Departamento preenchido.
+     */
+    private Departamento createDepartamento(Long id, String sigla, String nome) {
+        Departamento d = new Departamento();
+        d.setId(id);
+        d.setSigla(sigla);
+        d.setNome(nome);
+        return d;
+    }
+}


### PR DESCRIPTION
# Pull Request

## 📄 Descrição

Este PR implementa o módulo de **Departamentos**, incluindo:
- Criação da entidade `Departamento`
- Implementação de DTO, controller, service, testes unitários e integração
- Adição da migration `V1.2.3__create_tb_departamento.sql` para criação da tabela no banco

## ✅ Checklist
<!-- Marque os itens concluídos com um x (sem espaços ao redor) -->
- [x] Meu código segue a convenção de código definida no documento
- [x] Eu revisei o código que estou enviando para o PR
- [x] Eu adicionei Javadoc em funções públicas de negócio ou comentários em lugares necessários
- [x] Minhas mudanças não geraram nenhum warning
- [x] Eu rodei `mvn install` e não gerou erro
- [x] Cobri o código com teste unitário ou de integração
- [x] Não quebrei nenhum teste com minhas mudanças

## 🧪 Instruções de Teste
- Fazer `GET` em `/api/departamentos` para listar departamentos
