### PR TITLE
Refactor - mudança para resposta 422 quando código está expirado ou i…

### DIFF
--- a/src/main/java/br/edu/utfpr/pb/ext/server/auth/AuthService.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/auth/AuthService.java
@@ -145,7 +145,7 @@ public class AuthService {
           .findByEmail(dto.getEmail())
           .orElseThrow(() -> new UsernameNotFoundException(EMAIL_NAO_CADASTRADO));
     } catch (BadCredentialsException ex) {
-      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Código inválido ou expirado");
+      throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Código inválido ou expirado");
     }
   }
 }

--- a/src/test/java/br/edu/utfpr/pb/ext/server/auth/AuthControllerTest.java
+++ b/src/test/java/br/edu/utfpr/pb/ext/server/auth/AuthControllerTest.java
@@ -97,8 +97,8 @@ class AuthControllerTest {
   }
 
   @Test
-  @DisplayName("Autenticar com código OTP inválido deve retornar Unauthorized")
-  void autenticacao_whenCodigoOTPInvalido_DeveRetornar401() throws Exception {
+  @DisplayName("Autenticar com código OTP inválido deve retornar Unprocessable Entity")
+  void autenticacao_whenCodigoOTPInvalido_DeveRetornar422() throws Exception {
     EmailOtpAuthRequestDTO authRequestDTO =
         EmailOtpAuthRequestDTO.builder()
             .email("testuser@alunos.utfpr.edu.br")
@@ -110,7 +110,7 @@ class AuthControllerTest {
             post("/api/auth/login-otp")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(authRequestDTO)))
-        .andExpect(status().isUnauthorized());
+        .andExpect(status().isUnprocessableEntity());
   }
 
   @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correções de Bug**
  - Alterado o código de status HTTP retornado ao informar um código OTP inválido ou expirado de 401 (Não autorizado) para 422 (Entidade não processável), proporcionando uma resposta mais adequada ao usuário.

- **Testes**
  - Atualização dos testes automatizados para refletir a nova resposta HTTP 422 ao tentar autenticar com código OTP inválido.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->