### PR TITLE
correcao do endpoint de departamento

### DIFF
--- a/src/main/java/br/edu/utfpr/pb/ext/server/config/SecurityConfig.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/config/SecurityConfig.java
@@ -103,6 +103,8 @@ public class SecurityConfig {
                     .hasRole("SERVIDOR")
                     .requestMatchers(HttpMethod.OPTIONS, "/**") // CORS preflight
                     .permitAll()
+                    .requestMatchers("/api/departamentos/**")
+                     .permitAll()
                     .requestMatchers("/error")
                     .permitAll()
                     .anyRequest()

--- a/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoController.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoController.java
@@ -5,7 +5,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/departamentos")
+@RequestMapping("/departamentos")
 public class DepartamentoController extends CrudController<Departamento, DepartamentoDto, Long> {
 
   private final DepartamentoService departamentoService;


### PR DESCRIPTION
# Pull Request

## Descrição
<!-- Descreva as mudanças feitas no pull request-->

## Checklist
<!-- Marque itens concluídos com um x (sem espaços ao redor) -->
- [ ] Meu código segue a convenção de código definida no documento
- [ ] Eu revisei o código que estou enviando para o PR
- [ ] Eu adicionei Javadoc em funções públicas de negócio ou comentários em lugares necessários
- [ ] Minhas mudanças não geraram nenhum warning
- [ ] Eu rodei `mvn install` e não gerou erro
- [ ] Cobri o código com teste unitário ou de integração
- [ ] Não quebrei nenhum teste com minhas mudanças

## Instruções de Teste
<!-- Como testar o que foi feito, se houver necessidade. Ex: fazer POST /users com os dados "x": "x" no body -->

## Informação Adicional
<!-- Alguma outra coisa de contexto -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos Recursos**
  - Agora todos os usuários têm acesso irrestrito aos endpoints sob o caminho "/api/departamentos/**".

- **Refatoração**
  - O caminho base dos endpoints do controlador de departamentos foi alterado de "/api/departamentos" para "/departamentos".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->