### PR TITLE
bugfix - ajuste na permissão de acesso de departamentos

### DIFF
--- a/src/main/java/br/edu/utfpr/pb/ext/server/config/SecurityConfig.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/config/SecurityConfig.java
@@ -103,7 +103,7 @@ public class SecurityConfig {
                     .hasRole("SERVIDOR")
                     .requestMatchers(HttpMethod.OPTIONS, "/**") // CORS preflight
                     .permitAll()
-                    .requestMatchers("/api/departamentos/**")
+                    .requestMatchers(HttpMethod.GET, "/api/departamento/**")
                     .permitAll()
                     .requestMatchers("/error")
                     .permitAll()

--- a/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoController.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/departamento/DepartamentoController.java
@@ -5,7 +5,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/departamentos")
+@RequestMapping("/departamento")
 public class DepartamentoController extends CrudController<Departamento, DepartamentoDto, Long> {
 
   private final DepartamentoService departamentoService;


### PR DESCRIPTION
# Pull Request

## Descrição
<!-- Descreva as mudanças feitas no pull request-->

## Checklist
<!-- Marque itens concluídos com um x (sem espaços ao redor) -->
- [x] Meu código segue a convenção de código definida no documento
- [x] Eu revisei o código que estou enviando para o PR
- [x] Eu adicionei Javadoc em funções públicas de negócio ou comentários em lugares necessários
- [x] Minhas mudanças não geraram nenhum warning
- [x] Eu rodei `mvn install` e não gerou erro
- [x] Cobri o código com teste unitário ou de integração
- [x] Não quebrei nenhum teste com minhas mudanças

## Instruções de Teste
<!-- Como testar o que foi feito, se houver necessidade. Ex: fazer POST /users com os dados "x": "x" no body -->

## Informação Adicional
<!-- Alguma outra coisa de contexto -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Mudanças de Funcionalidade**
  - O endpoint dos departamentos foi alterado de "/departamentos" para "/departamento".
  - Agora, apenas requisições HTTP GET para "/api/departamento/**" são permitidas sem autenticação; outros métodos e caminhos exigem autenticação.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->