### PR TITLE
PEXT-33 feat: Add endpoint to retrieve all users and update security configuration

### DIFF
--- a/src/main/java/br/edu/utfpr/pb/ext/server/config/SecurityConfig.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/config/SecurityConfig.java
@@ -105,6 +105,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers("/api/departamentos/**")
                     .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/usuarios/executores")
+                    .hasRole("SERVIDOR")
                     .requestMatchers("/error")
                     .permitAll()
                     .anyRequest()

--- a/src/main/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioController.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioController.java
@@ -116,10 +116,8 @@ public class UsuarioController extends CrudController<Usuario, UsuarioServidorRe
 
   /****
    * Cria um novo usuário com perfil de aluno e retorna uma resposta de login com token JWT e tempo de expiração.
-   *
    * Retorna HTTP 200 com o token de autenticação e tempo de expiração caso a criação seja bem-sucedida.
    * Retorna HTTP 400 se a autoridade "ROLE_ALUNO" não for encontrada.
-   *
    * @param usuarioAlunoRequestDTO dados do usuário aluno a ser criado
    * @return resposta HTTP 200 com token e expiração, ou HTTP 400 se a autoridade não existir
    */
@@ -167,7 +165,7 @@ public class UsuarioController extends CrudController<Usuario, UsuarioServidorRe
             content =
                 @Content(
                     mediaType = "application/json",
-                    schema = @Schema(implementation = UsuarioServidorResponseDTO.class)))
+                    schema = @Schema(implementation = UsuarioProjetoDTO.class)))
       })
   @GetMapping("/executores")
   public ResponseEntity<List<UsuarioProjetoDTO>> getAllUsers() {

--- a/src/main/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioController.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioController.java
@@ -7,10 +7,7 @@ import br.edu.utfpr.pb.ext.server.generics.CrudController;
 import br.edu.utfpr.pb.ext.server.generics.ICrudService;
 import br.edu.utfpr.pb.ext.server.usuario.authority.Authority;
 import br.edu.utfpr.pb.ext.server.usuario.authority.AuthorityRepository;
-import br.edu.utfpr.pb.ext.server.usuario.dto.UsuarioAlunoRequestDTO;
-import br.edu.utfpr.pb.ext.server.usuario.dto.UsuarioLogadoInfoDTO;
-import br.edu.utfpr.pb.ext.server.usuario.dto.UsuarioServidorRequestDTO;
-import br.edu.utfpr.pb.ext.server.usuario.dto.UsuarioServidorResponseDTO;
+import br.edu.utfpr.pb.ext.server.usuario.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.modelmapper.ModelMapper;
@@ -156,6 +154,29 @@ public class UsuarioController extends CrudController<Usuario, UsuarioServidorRe
     Usuario usuario = usuarioService.obterUsuarioLogado();
     UsuarioLogadoInfoDTO responseDTO = modelMapper.map(usuario, UsuarioLogadoInfoDTO.class);
     return ResponseEntity.ok(responseDTO);
+  }
+
+  @Operation(
+      summary = "Get all users",
+      description = "Returns a list of all registered users in the system")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Users retrieved successfully",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = UsuarioServidorResponseDTO.class)))
+      })
+  @GetMapping("/executores")
+  public ResponseEntity<List<UsuarioProjetoDTO>> getAllUsers() {
+    List<Usuario> usuarios = usuarioService.findAll();
+    List<UsuarioProjetoDTO> responseList =
+        usuarios.stream()
+            .map(usuario -> modelMapper.map(usuario, UsuarioProjetoDTO.class))
+            .toList();
+    return ResponseEntity.ok(responseList);
   }
 
   /**


### PR DESCRIPTION
# Pull Request

## Descrição
<!-- Descreva as mudanças feitas no pull request-->

## Checklist
<!-- Marque itens concluídos com um x (sem espaços ao redor) -->
- [ ] Meu código segue a convenção de código definida no documento
- [ ] Eu revisei o código que estou enviando para o PR
- [ ] Eu adicionei Javadoc em funções públicas de negócio ou comentários em lugares necessários
- [ ] Minhas mudanças não geraram nenhum warning
- [ ] Eu rodei `mvn install` e não gerou erro
- [ ] Cobri o código com teste unitário ou de integração
- [ ] Não quebrei nenhum teste com minhas mudanças

## Instruções de Teste
<!-- Como testar o que foi feito, se houver necessidade. Ex: fazer POST /users com os dados "x": "x" no body -->

## Informação Adicional
<!-- Alguma outra coisa de contexto -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Novos Recursos**
  - Adicionado um novo endpoint GET `/api/usuarios/executores` que retorna a lista de usuários cadastrados, acessível apenas para usuários com o papel "SERVIDOR".

- **Testes**
  - Incluídos testes para verificar o acesso autenticado e não autenticado ao novo endpoint, garantindo o correto controle de permissões e o retorno adequado dos dados.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->