### PR TITLE
retorno mensagem email errado equipe executora

### DIFF
--- a/src/main/java/br/edu/utfpr/pb/ext/server/projeto/ProjetoController.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/projeto/ProjetoController.java
@@ -21,6 +21,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("projeto")
@@ -103,13 +104,15 @@ public class ProjetoController extends CrudController<Projeto, ProjetoDTO, Long>
     List<String> emails =
         dto.getEquipeExecutora().stream().map(UsuarioProjetoDTO::getEmail).toList();
     if (emails.isEmpty()) {
-      return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).body(null);
+      throw new ResponseStatusException(
+              HttpStatus.NOT_ACCEPTABLE,  "A equipe executora não pode estar vazia.");
     }
     ArrayList<Optional<Usuario>> usuarios = new ArrayList<>();
     for (String email : emails) {
       Optional<Usuario> usuario = usuarioRepository.findByEmail(email);
       if (usuario.isEmpty()) {
-        return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).body(null);
+        throw new ResponseStatusException(
+                HttpStatus.NOT_ACCEPTABLE, "Usuário com e-mail " + email + " não encontrado.");
       }
       usuarios.add(usuario);
     }


### PR DESCRIPTION
As validações foram aplicadas no método de criação de projeto
---

## Checklist
<!-- Marque os itens concluídos com um x (ex: [x]) -->

- [x] Meu código segue a convenção de código definida no documento
- [x] Eu revisei o código que estou enviando para o PR
- [x] Eu adicionei Javadoc em funções públicas de negócio ou comentários em lugares necessários
- [x] Minhas mudanças não geraram nenhum warning
- [x] Eu rodei `mvn install` e não gerou erro
- [x] Cobri o código com teste unitário ou de integração
- [x] Não quebrei nenhum teste com minhas mudanças

---

## Instruções de Teste

### 🚩 Criação de Projeto (POST `/projeto`)

✅ Caso 1: Enviar equipe executora com e-mail inexistente → Deve retornar: 
HTTP 406
Usuário com e-mail X não encontrado.
✅ Caso 2: Enviar equipe executora vazia → Deve retornar:
HTTP 406
A equipe executora não pode estar vazia.
✅ Caso 3: Enviar com todos os e-mails válidos → Projeto criado com sucesso (`201 Created`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Correções de Erros**
  - As mensagens de erro ao criar um projeto agora são exibidas de forma mais clara quando a equipe executora está vazia ou quando algum e-mail informado não corresponde a um usuário existente, com notificações mais detalhadas ao usuário.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->