### PR TITLE
add migration faltando cancelamento projto

### DIFF
--- a/src/main/resources/db/migration/V1.3.3__add_motivo_cancelamento_projeto.sql
+++ b/src/main/resources/db/migration/V1.3.3__add_motivo_cancelamento_projeto.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tb_projeto ADD COLUMN justificativa_cancelamento VARCHAR(100);


### PR DESCRIPTION
# Pull Request

## Descrição

Correção de erro ao consultar a tabela `tb_projeto` no endpoint GET `/api/projetos`.

Foi identificado que a aplicação estava tentando acessar a coluna `justificativa_cancelamento`, que não existia no banco de dados.  
Para resolver, foi criada uma migration adicionando essa coluna na tabela `tb_projeto`.

---

## Checklist

<!-- Marque itens concluídos com um x (sem espaços ao redor) -->

- [x] Meu código segue a convenção de código definida no documento
- [x] Eu revisei o código que estou enviando para o PR
- [x] Eu adicionei Javadoc em funções públicas de negócio ou comentários em lugares necessários
- [x] Minhas mudanças não geraram nenhum warning
- [x] Eu rodei `mvn install` e não gerou erro
- [x] Cobri o código com teste unitário ou de integração (se aplicável)
- [x] Não quebrei nenhum teste com minhas mudanças

---

## Instruções de Teste

- Executar o endpoint GET `/api/projetos`.
- Verificar que o erro relacionado à ausência da coluna `justificativa_cancelamento` não ocorre mais.
- Confirmar que a listagem de projetos está funcionando normalmente.

---

## Informação Adicional

- Migration aplicada no banco PostgreSQL:

```sql
ALTER TABLE tb_projeto ADD COLUMN justificativa_cancelamento VARCHAR(100);

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos Recursos**
  - Adicionada a possibilidade de registrar a justificativa de cancelamento em projetos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->