### PR TITLE
removida a obrigatoriedade do campo telefone no DTO de cadastro de se…

### DIFF
--- a/src/main/java/br/edu/utfpr/pb/ext/server/usuario/dto/UsuarioServidorRequestDTO.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/usuario/dto/UsuarioServidorRequestDTO.java
@@ -3,6 +3,7 @@ package br.edu.utfpr.pb.ext.server.usuario.dto;
 import br.edu.utfpr.pb.ext.server.usuario.enums.Departamentos;
 import br.edu.utfpr.pb.ext.server.usuario.validation.annotation.UniqueCpf;
 import br.edu.utfpr.pb.ext.server.usuario.validation.annotation.UniqueSiape;
+import io.micrometer.common.lang.Nullable;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import org.hibernate.validator.constraints.br.CPF;
@@ -28,7 +29,9 @@ public class UsuarioServidorRequestDTO {
       message = "{br.edu.utfpr.pb.ext.server.usuario.dto.UsuarioServidorRequestDTO.email}")
   private String email;
 
-  @Size(min = 11, max = 11) private String telefone;
+  @Nullable
+  @Size(min = 10, max = 15, message = "O telefone deve ter entre 10 e 15 caracteres, se informado.")
+  private String telefone;
 
   @Size(min = 3, max = 100) private String enderecoCompleto;
 


### PR DESCRIPTION
# Pull Request

## Descrição
Removida a obrigatoriedade do campo `telefone` no cadastro de servidores.

Agora o campo pode ser nulo ou ausente no JSON de entrada.  
Mantida a validação de tamanho apenas se o campo for informado.

## Checklist
<!-- Marque itens concluídos com um x (sem espaços ao redor) -->
- [x] Meu código segue a convenção de código definida no documento
- [x] Eu revisei o código que estou enviando para o PR
- [x] Eu adicionei Javadoc em funções públicas de negócio ou comentários em lugares necessários
- [x] Minhas mudanças não geraram nenhum warning
- [x] Eu rodei `mvn install` e não gerou erro
- [x] Cobri o código com teste unitário ou de integração
- [x] Não quebrei nenhum teste com minhas mudanças

## Instruções de Teste
1. Realizar um POST no endpoint de cadastro de servidor (`/api/usuarios/servidores`).
2. Testar o cadastro com os seguintes cenários:
   - ✅ JSON com o campo `telefone` preenchido com valor válido (10 a 15 caracteres).
   - ✅ JSON sem o campo `telefone`.
   - ✅ JSON com o campo `telefone` como `null`.
   - ❌ JSON com o campo `telefone` com menos de 10 ou mais de 15 caracteres → Deve gerar erro de validação.

## Informação Adicional
Essa alteração foi feita conforme a especificação do projeto, que definiu o campo `telefone` como opcional para servidores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos Recursos**
  - O campo de telefone agora é opcional e pode ser deixado em branco.
- **Ajustes**
  - Caso informado, o telefone deve ter entre 10 e 15 caracteres.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->