### PR TITLE
PEXT156 bugfix:add quantity and workload fields to project creation

### DIFF
--- a/src/main/java/br/edu/utfpr/pb/ext/server/projeto/ProjetoController.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/projeto/ProjetoController.java
@@ -127,6 +127,8 @@ public class ProjetoController extends CrudController<Projeto, ProjetoDTO, Long>
     projeto.setRestricaoPublico(dto.getRestricaoPublico());
     projeto.setEquipeExecutora(usuarios.stream().flatMap(Optional::stream).toList());
     projeto.setStatus(StatusProjeto.EM_ANDAMENTO);
+    projeto.setQtdeVagas(dto.getQtdeVagas());
+    projeto.setCargaHoraria(dto.getCargaHoraria());
     Projeto projetoResponse = projetoService.save(projeto);
     ProjetoDTO projetoDTO = modelMapper.map(projetoResponse, ProjetoDTO.class);
     return ResponseEntity.status(HttpStatus.CREATED).body(projetoDTO);

--- a/src/main/java/br/edu/utfpr/pb/ext/server/usuario/dto/UsuarioServidorRequestDTO.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/usuario/dto/UsuarioServidorRequestDTO.java
@@ -29,9 +29,7 @@ public class UsuarioServidorRequestDTO {
       message = "{br.edu.utfpr.pb.ext.server.usuario.dto.UsuarioServidorRequestDTO.email}")
   private String email;
 
-  @Nullable
-  @Size(min = 10, max = 15, message = "O telefone deve ter entre 10 e 15 caracteres, se informado.")
-  private String telefone;
+  @Nullable @Size(min = 10, max = 15, message = "O telefone deve ter entre 10 e 15 caracteres, se informado.") private String telefone;
 
   @Size(min = 3, max = 100) private String enderecoCompleto;
 


### PR DESCRIPTION
# Pull Request

## Descrição
<!-- Descreva as mudanças feitas no pull request-->

## Checklist
<!-- Marque itens concluídos com um x (sem espaços ao redor) -->
- [ ] Meu código segue a convenção de código definida no documento
- [ ] Eu revisei o código que estou enviando para o PR
- [ ] Eu adicionei Javadoc em funções públicas de negócio ou comentários em lugares necessários
- [ ] Minhas mudanças não geraram nenhum warning
- [ ] Eu rodei `mvn install` e não gerou erro
- [ ] Cobri o código com teste unitário ou de integração
- [ ] Não quebrei nenhum teste com minhas mudanças

## Instruções de Teste
<!-- Como testar o que foi feito, se houver necessidade. Ex: fazer POST /users com os dados "x": "x" no body -->

## Informação Adicional
<!-- Alguma outra coisa de contexto -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos Recursos**
  - Agora, ao criar um projeto, os campos "Quantidade de Vagas" e "Carga Horária" são definidos automaticamente a partir das informações fornecidas.

- **Estilo**
  - Ajuste no formato da declaração do campo de telefone, sem impacto no funcionamento ou validação.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->