### PR TITLE
PEXT-201 feat: update authentication handling to return 401 for unauthorized access

### DIFF
--- a/src/main/java/br/edu/utfpr/pb/ext/server/config/EntryPointUnauthorizedHandler.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/config/EntryPointUnauthorizedHandler.java
@@ -1,0 +1,23 @@
+package br.edu.utfpr.pb.ext.server.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component(value = "authenticationEntryPoint")
+public class EntryPointUnauthorizedHandler implements AuthenticationEntryPoint {
+
+  @Override
+  public void commence(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException)
+      throws IOException, ServletException {
+    response.sendError(HttpStatus.UNAUTHORIZED.value(), HttpStatus.UNAUTHORIZED.getReasonPhrase());
+  }
+}

--- a/src/main/java/br/edu/utfpr/pb/ext/server/config/SecurityConfig.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/config/SecurityConfig.java
@@ -33,6 +33,8 @@ public class SecurityConfig {
   private final Environment environment;
   private final EmailOtpAuthenticationProvider emailOtpAuthenticationProvider;
 
+  private final EntryPointUnauthorizedHandler entryPointUnauthorizedHandler;
+
   /**
    * Injeta a chave app.client.origins e os valores existentes separados por vírgula configurado no
    * yml
@@ -51,9 +53,12 @@ public class SecurityConfig {
    * @param emailOtpAuthenticationProvider provedor de autenticação OTP por e-mail
    */
   public SecurityConfig(
-      Environment environment, EmailOtpAuthenticationProvider emailOtpAuthenticationProvider) {
+      Environment environment,
+      EmailOtpAuthenticationProvider emailOtpAuthenticationProvider,
+      EntryPointUnauthorizedHandler entryPointUnauthorizedHandler) {
     this.environment = environment;
     this.emailOtpAuthenticationProvider = emailOtpAuthenticationProvider;
+    this.entryPointUnauthorizedHandler = entryPointUnauthorizedHandler;
   }
 
   /**
@@ -75,6 +80,8 @@ public class SecurityConfig {
     http.cors(c -> c.configurationSource(corsConfigurationSource()))
         .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**", "/h2-console/**"))
         .headers(h -> h.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+        .exceptionHandling(
+            exceptions -> exceptions.authenticationEntryPoint(entryPointUnauthorizedHandler))
         .authorizeHttpRequests(
             authorize ->
                 authorize

--- a/src/main/resources/templates/notification-template.html
+++ b/src/main/resources/templates/notification-template.html
@@ -94,7 +94,7 @@
             <table class="email-container">
                 <tr>
                     <td class="email-header">
-                        <img src="https://media.discordapp.net/attachments/1364952900220227698/1388177985130991718/logo-utf-mais-prod.png?ex=686008fe&is=685eb77e&hm=c30e8efca9c656b6a8bb21b82cbd2f894b990e9413d9994159f3f6d30aa4da4f&=&format=webp&quality=lossless&width=2574&height=918" alt="Logo UTFPR" width="120"/>
+                        <img src="https://kirinus.tec.br:9000/utfpr-bucket/logo-utf-mais-prod.png" alt="Logo UTFPR" width="120"/>
                     </td>
                 </tr>
                 <tr>

--- a/src/main/resources/templates/otp-template.html
+++ b/src/main/resources/templates/otp-template.html
@@ -90,7 +90,7 @@
             <table class="email-container">
                 <tr>
                     <td class="email-header">
-                        <img src="https://media.discordapp.net/attachments/1364952900220227698/1388177985130991718/logo-utf-mais-prod.png?ex=686008fe&is=685eb77e&hm=c30e8efca9c656b6a8bb21b82cbd2f894b990e9413d9994159f3f6d30aa4da4f&=&format=webp&quality=lossless&width=2574&height=918" alt="Logo UTFPR" width="120"/>
+                        <img src="https://kirinus.tec.br:9000/utfpr-bucket/logo-utf-mais-prod.png" alt="Logo UTFPR" width="120"/>
                     </td>
                 </tr>
                 <tr>

--- a/src/test/java/br/edu/utfpr/pb/ext/server/notificacao/NotificacaoServiceImplTest.java
+++ b/src/test/java/br/edu/utfpr/pb/ext/server/notificacao/NotificacaoServiceImplTest.java
@@ -75,16 +75,18 @@ class NotificacaoServiceImplTest {
   }
 
   private Usuario createUsuario(Long id, String nome, String email) {
-    return Usuario.builder()
-        .id(id)
-        .nome(nome)
-        .email(email)
-        .build();
+    return Usuario.builder().id(id).nome(nome).email(email).build();
   }
 
-  private Notificacao createTestNotificacao(Long id, String titulo, String descricao, 
-                                          TipoNotificacao tipo, TipoReferencia tipoReferencia,
-                                          Long referenciaId, Usuario usuario, boolean lida) {
+  private Notificacao createTestNotificacao(
+      Long id,
+      String titulo,
+      String descricao,
+      TipoNotificacao tipo,
+      TipoReferencia tipoReferencia,
+      Long referenciaId,
+      Usuario usuario,
+      boolean lida) {
     return Notificacao.builder()
         .id(id)
         .titulo(titulo)
@@ -99,9 +101,15 @@ class NotificacaoServiceImplTest {
   }
 
   private Notificacao createSimpleNotificacao(Long id, Usuario usuario, boolean lida) {
-    return createTestNotificacao(id, TITULO_TESTE, DESCRICAO_TESTE, 
-                               TipoNotificacao.INFO, TipoReferencia.PROJETO, 
-                               REFERENCIA_ID_TESTE, usuario, lida);
+    return createTestNotificacao(
+        id,
+        TITULO_TESTE,
+        DESCRICAO_TESTE,
+        TipoNotificacao.INFO,
+        TipoReferencia.PROJETO,
+        REFERENCIA_ID_TESTE,
+        usuario,
+        lida);
   }
 
   private List<Notificacao> capturarNotificacoesSalvas() {
@@ -110,8 +118,12 @@ class NotificacaoServiceImplTest {
     return captor.getValue();
   }
 
-  private void assertNotificacaoBasica(Notificacao notificacao, String titulo, String descricao, 
-                                      TipoNotificacao tipo, Usuario usuario) {
+  private void assertNotificacaoBasica(
+      Notificacao notificacao,
+      String titulo,
+      String descricao,
+      TipoNotificacao tipo,
+      Usuario usuario) {
     assertEquals(titulo, notificacao.getTitulo());
     assertEquals(descricao, notificacao.getDescricao());
     assertEquals(tipo, notificacao.getTipoNotificacao());
@@ -146,10 +158,9 @@ class NotificacaoServiceImplTest {
     void deveLancarExceptionQuandoUsuarioNaoEhProprietario() {
       when(notificacaoRepository.findById(1L)).thenReturn(Optional.of(notificacao1));
 
-      ResponseStatusException exception = assertThrows(
-          ResponseStatusException.class,
-          () -> notificacaoService.marcarComoLida(1L, usuario2)
-      );
+      ResponseStatusException exception =
+          assertThrows(
+              ResponseStatusException.class, () -> notificacaoService.marcarComoLida(1L, usuario2));
 
       assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, exception.getStatusCode());
       assertFalse(notificacao1.isLida());
@@ -162,9 +173,7 @@ class NotificacaoServiceImplTest {
       when(notificacaoRepository.findById(99L)).thenReturn(Optional.empty());
 
       assertThrows(
-          EntityNotFoundException.class,
-          () -> notificacaoService.marcarComoLida(99L, usuario1)
-      );
+          EntityNotFoundException.class, () -> notificacaoService.marcarComoLida(99L, usuario1));
 
       verify(notificacaoRepository, never()).save(any());
     }
@@ -178,14 +187,16 @@ class NotificacaoServiceImplTest {
     @DisplayName("buscarNotificacoesDoUsuario deve retornar page de NotificacaoDTO")
     void buscarNotificacoesDoUsuario_deveRetornarPageDeNotificacaoDTO() {
       List<Notificacao> notificacoes = Arrays.asList(notificacao1, notificacao2);
-      Page<Notificacao> pageNotificacoes = new PageImpl<>(notificacoes, pageable, notificacoes.size());
-      
+      Page<Notificacao> pageNotificacoes =
+          new PageImpl<>(notificacoes, pageable, notificacoes.size());
+
       when(notificacaoRepository.findByUsuarioOrderByDataCriacaoDesc(usuario1, pageable))
           .thenReturn(pageNotificacoes);
       when(modelMapper.map(notificacao1, NotificacaoDTO.class)).thenReturn(notificacaoDTO1);
       when(modelMapper.map(notificacao2, NotificacaoDTO.class)).thenReturn(notificacaoDTO2);
 
-      Page<NotificacaoDTO> result = notificacaoService.buscarNotificacoesDoUsuario(usuario1, pageable);
+      Page<NotificacaoDTO> result =
+          notificacaoService.buscarNotificacoesDoUsuario(usuario1, pageable);
 
       assertEquals(2, result.getContent().size());
       assertEquals(notificacaoDTO1, result.getContent().get(0));
@@ -197,17 +208,21 @@ class NotificacaoServiceImplTest {
     @DisplayName("buscarNotificacoesNaoLidas deve retornar apenas notificacoes nao lidas")
     void buscarNotificacoesNaoLidas_deveRetornarApenasNotificacoesNaoLidas() {
       List<Notificacao> notificacoesNaoLidas = Collections.singletonList(notificacao1);
-      Page<Notificacao> pageNotificacoesNaoLidas = new PageImpl<>(notificacoesNaoLidas, pageable, 1);
-      
-      when(notificacaoRepository.findByUsuarioAndLidaFalseOrderByDataCriacaoDesc(usuario1, pageable))
+      Page<Notificacao> pageNotificacoesNaoLidas =
+          new PageImpl<>(notificacoesNaoLidas, pageable, 1);
+
+      when(notificacaoRepository.findByUsuarioAndLidaFalseOrderByDataCriacaoDesc(
+              usuario1, pageable))
           .thenReturn(pageNotificacoesNaoLidas);
       when(modelMapper.map(notificacao1, NotificacaoDTO.class)).thenReturn(notificacaoDTO1);
 
-      Page<NotificacaoDTO> result = notificacaoService.buscarNotificacoesNaoLidas(usuario1, pageable);
+      Page<NotificacaoDTO> result =
+          notificacaoService.buscarNotificacoesNaoLidas(usuario1, pageable);
 
       assertEquals(1, result.getContent().size());
       assertEquals(notificacaoDTO1, result.getContent().getFirst());
-      verify(notificacaoRepository).findByUsuarioAndLidaFalseOrderByDataCriacaoDesc(usuario1, pageable);
+      verify(notificacaoRepository)
+          .findByUsuarioAndLidaFalseOrderByDataCriacaoDesc(usuario1, pageable);
     }
   }
 
@@ -240,8 +255,12 @@ class NotificacaoServiceImplTest {
       List<Usuario> destinatarios = Arrays.asList(usuario1, usuario2, usuario3);
 
       notificacaoService.criarNotificacaoParaMultiplosUsuarios(
-          destinatarios, TITULO_TESTE, DESCRICAO_TESTE, 
-          TipoNotificacao.INFO, TipoReferencia.PROJETO, REFERENCIA_ID_TESTE);
+          destinatarios,
+          TITULO_TESTE,
+          DESCRICAO_TESTE,
+          TipoNotificacao.INFO,
+          TipoReferencia.PROJETO,
+          REFERENCIA_ID_TESTE);
 
       List<Notificacao> notificacoesSalvas = capturarNotificacoesSalvas();
       assertEquals(TOTAL_USUARIOS_TESTE, notificacoesSalvas.size());
@@ -249,8 +268,8 @@ class NotificacaoServiceImplTest {
       for (int i = 0; i < TOTAL_USUARIOS_TESTE; i++) {
         Notificacao notificacao = notificacoesSalvas.get(i);
         Usuario usuarioEsperado = destinatarios.get(i);
-        assertNotificacaoBasica(notificacao, TITULO_TESTE, DESCRICAO_TESTE, 
-                              TipoNotificacao.INFO, usuarioEsperado);
+        assertNotificacaoBasica(
+            notificacao, TITULO_TESTE, DESCRICAO_TESTE, TipoNotificacao.INFO, usuarioEsperado);
       }
     }
 
@@ -260,8 +279,12 @@ class NotificacaoServiceImplTest {
       List<Usuario> destinatarios = Arrays.asList(usuario1, null, usuario2);
 
       notificacaoService.criarNotificacaoParaMultiplosUsuarios(
-          destinatarios, TITULO_TESTE, DESCRICAO_TESTE, 
-          TipoNotificacao.INFO, TipoReferencia.PROJETO, REFERENCIA_ID_TESTE);
+          destinatarios,
+          TITULO_TESTE,
+          DESCRICAO_TESTE,
+          TipoNotificacao.INFO,
+          TipoReferencia.PROJETO,
+          REFERENCIA_ID_TESTE);
 
       List<Notificacao> notificacoesSalvas = capturarNotificacoesSalvas();
       assertEquals(2, notificacoesSalvas.size());
@@ -275,8 +298,12 @@ class NotificacaoServiceImplTest {
       List<Usuario> destinatarios = Collections.emptyList();
 
       notificacaoService.criarNotificacaoParaMultiplosUsuarios(
-          destinatarios, TITULO_TESTE, DESCRICAO_TESTE, 
-          TipoNotificacao.INFO, TipoReferencia.PROJETO, REFERENCIA_ID_TESTE);
+          destinatarios,
+          TITULO_TESTE,
+          DESCRICAO_TESTE,
+          TipoNotificacao.INFO,
+          TipoReferencia.PROJETO,
+          REFERENCIA_ID_TESTE);
 
       List<Notificacao> notificacoesSalvas = capturarNotificacoesSalvas();
       assertTrue(notificacoesSalvas.isEmpty());
@@ -288,8 +315,12 @@ class NotificacaoServiceImplTest {
       List<Usuario> destinatarios = Arrays.asList(null, null, null);
 
       notificacaoService.criarNotificacaoParaMultiplosUsuarios(
-          destinatarios, TITULO_TESTE, DESCRICAO_TESTE, 
-          TipoNotificacao.INFO, TipoReferencia.PROJETO, REFERENCIA_ID_TESTE);
+          destinatarios,
+          TITULO_TESTE,
+          DESCRICAO_TESTE,
+          TipoNotificacao.INFO,
+          TipoReferencia.PROJETO,
+          REFERENCIA_ID_TESTE);
 
       List<Notificacao> notificacoesSalvas = capturarNotificacoesSalvas();
       assertTrue(notificacoesSalvas.isEmpty());
@@ -301,13 +332,21 @@ class NotificacaoServiceImplTest {
       List<Usuario> destinatarios = Collections.singletonList(usuario1);
 
       notificacaoService.criarNotificacaoParaMultiplosUsuarios(
-          destinatarios, TITULO_TESTE, DESCRICAO_TESTE, 
-          TipoNotificacao.INFO, TipoReferencia.PROJETO, REFERENCIA_ID_TESTE);
+          destinatarios,
+          TITULO_TESTE,
+          DESCRICAO_TESTE,
+          TipoNotificacao.INFO,
+          TipoReferencia.PROJETO,
+          REFERENCIA_ID_TESTE);
 
       List<Notificacao> notificacoesSalvas = capturarNotificacoesSalvas();
       assertEquals(1, notificacoesSalvas.size());
-      assertNotificacaoBasica(notificacoesSalvas.getFirst(), TITULO_TESTE, DESCRICAO_TESTE,
-                            TipoNotificacao.INFO, usuario1);
+      assertNotificacaoBasica(
+          notificacoesSalvas.getFirst(),
+          TITULO_TESTE,
+          DESCRICAO_TESTE,
+          TipoNotificacao.INFO,
+          usuario1);
     }
 
     @Test
@@ -317,12 +356,16 @@ class NotificacaoServiceImplTest {
       LocalDateTime antes = LocalDateTime.now().minusSeconds(1);
 
       notificacaoService.criarNotificacaoParaMultiplosUsuarios(
-          destinatarios, TITULO_TESTE, DESCRICAO_TESTE, 
-          TipoNotificacao.INFO, TipoReferencia.PROJETO, REFERENCIA_ID_TESTE);
+          destinatarios,
+          TITULO_TESTE,
+          DESCRICAO_TESTE,
+          TipoNotificacao.INFO,
+          TipoReferencia.PROJETO,
+          REFERENCIA_ID_TESTE);
 
       List<Notificacao> notificacoesSalvas = capturarNotificacoesSalvas();
       LocalDateTime depois = LocalDateTime.now().plusSeconds(1);
-      
+
       Notificacao notificacao = notificacoesSalvas.getFirst();
       assertTrue(notificacao.getDataCriacao().isAfter(antes));
       assertTrue(notificacao.getDataCriacao().isBefore(depois));
@@ -334,8 +377,12 @@ class NotificacaoServiceImplTest {
       List<Usuario> destinatarios = Arrays.asList(usuario1, usuario2);
 
       notificacaoService.criarNotificacaoParaMultiplosUsuarios(
-          destinatarios, TITULO_TESTE, DESCRICAO_TESTE, 
-          TipoNotificacao.INFO, TipoReferencia.PROJETO, REFERENCIA_ID_TESTE);
+          destinatarios,
+          TITULO_TESTE,
+          DESCRICAO_TESTE,
+          TipoNotificacao.INFO,
+          TipoReferencia.PROJETO,
+          REFERENCIA_ID_TESTE);
 
       List<Notificacao> notificacoesSalvas = capturarNotificacoesSalvas();
       notificacoesSalvas.forEach(notificacao -> assertFalse(notificacao.isLida()));
@@ -347,8 +394,12 @@ class NotificacaoServiceImplTest {
       List<Usuario> destinatarios = Collections.singletonList(usuario1);
 
       notificacaoService.criarNotificacaoParaMultiplosUsuarios(
-          destinatarios, TITULO_TESTE, DESCRICAO_TESTE, 
-          TipoNotificacao.INFO, TipoReferencia.PROJETO, null);
+          destinatarios,
+          TITULO_TESTE,
+          DESCRICAO_TESTE,
+          TipoNotificacao.INFO,
+          TipoReferencia.PROJETO,
+          null);
 
       List<Notificacao> notificacoesSalvas = capturarNotificacoesSalvas();
       assertEquals(1, notificacoesSalvas.size());
@@ -362,8 +413,12 @@ class NotificacaoServiceImplTest {
       List<Usuario> destinatarios = Collections.singletonList(usuario1);
 
       notificacaoService.criarNotificacaoParaMultiplosUsuarios(
-          destinatarios, TITULO_TESTE, DESCRICAO_TESTE, 
-          tipo, TipoReferencia.PROJETO, REFERENCIA_ID_TESTE);
+          destinatarios,
+          TITULO_TESTE,
+          DESCRICAO_TESTE,
+          tipo,
+          TipoReferencia.PROJETO,
+          REFERENCIA_ID_TESTE);
 
       List<Notificacao> notificacoesSalvas = capturarNotificacoesSalvas();
       assertEquals(1, notificacoesSalvas.size());
@@ -377,8 +432,12 @@ class NotificacaoServiceImplTest {
       List<Usuario> destinatarios = Collections.singletonList(usuario1);
 
       notificacaoService.criarNotificacaoParaMultiplosUsuarios(
-          destinatarios, TITULO_TESTE, DESCRICAO_TESTE, 
-          TipoNotificacao.INFO, tipoReferencia, REFERENCIA_ID_TESTE);
+          destinatarios,
+          TITULO_TESTE,
+          DESCRICAO_TESTE,
+          TipoNotificacao.INFO,
+          tipoReferencia,
+          REFERENCIA_ID_TESTE);
 
       List<Notificacao> notificacoesSalvas = capturarNotificacoesSalvas();
       assertEquals(1, notificacoesSalvas.size());
@@ -387,21 +446,25 @@ class NotificacaoServiceImplTest {
 
     @ParameterizedTest
     @CsvSource({
-        "Título Teste 1, Descrição Teste 1",
-        "Título Teste 2, Descrição Teste 2",
-        "Título Teste 3, Descrição Teste 3"
+      "Título Teste 1, Descrição Teste 1",
+      "Título Teste 2, Descrição Teste 2",
+      "Título Teste 3, Descrição Teste 3"
     })
     @DisplayName("deve criar notificacao com diferentes dados")
     void deveCriarNotificacaoComDiferentesDados(String titulo, String descricao) {
       List<Usuario> destinatarios = Collections.singletonList(usuario1);
 
       notificacaoService.criarNotificacaoParaMultiplosUsuarios(
-          destinatarios, titulo, descricao, 
-          TipoNotificacao.INFO, TipoReferencia.PROJETO, REFERENCIA_ID_TESTE);
+          destinatarios,
+          titulo,
+          descricao,
+          TipoNotificacao.INFO,
+          TipoReferencia.PROJETO,
+          REFERENCIA_ID_TESTE);
 
       List<Notificacao> notificacoesSalvas = capturarNotificacoesSalvas();
       assertEquals(1, notificacoesSalvas.size());
-      
+
       Notificacao notificacao = notificacoesSalvas.getFirst();
       assertEquals(titulo, notificacao.getTitulo());
       assertEquals(descricao, notificacao.getDescricao());

--- a/src/test/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioControllerTest.java
+++ b/src/test/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioControllerTest.java
@@ -209,30 +209,27 @@ class UsuarioControllerTest {
     ResponseEntity<Object> response =
         testRestTemplate.getForEntity("/api/usuarios/meu-perfil", Object.class);
 
-    assertEquals(403, response.getStatusCode().value());
+    assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatusCode().value());
   }
 
   @Test
   void getAllUsers_whenUnauthenticated_receiveForbidden() {
-    // Ensure no authentication headers are present
     testRestTemplate.getRestTemplate().getInterceptors().clear();
 
     ResponseEntity<Object> response =
         testRestTemplate.getForEntity("/api/usuarios/executores", Object.class);
 
-    assertEquals(403, response.getStatusCode().value());
+    assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatusCode().value());
   }
 
   @Test
   void getAllUsers_whenAuthenticated_receiveListOfUsers() {
-    // Create a user and authenticate
     UsuarioServidorRequestDTO request = createUsuarioServidorRequestDTO();
     ResponseEntity<RespostaLoginDTO> loginResponse =
         testRestTemplate.postForEntity(API_USERS, request, RespostaLoginDTO.class);
 
     String token = loginResponse.getBody().getToken();
 
-    // Add authentication header for subsequent requests
     testRestTemplate
         .getRestTemplate()
         .getInterceptors()
@@ -242,16 +239,13 @@ class UsuarioControllerTest {
               return execution.execute(httpRequest, bytes);
             });
 
-    // Call the endpoint
     ResponseEntity<UsuarioProjetoDTO[]> response =
         testRestTemplate.getForEntity("/api/usuarios/executores", UsuarioProjetoDTO[].class);
 
-    // Verify response
     assertEquals(200, response.getStatusCode().value());
     assertNotNull(response.getBody());
     assertEquals(1, response.getBody().length);
 
-    // Verify user data
     boolean foundFirstUser = false;
 
     for (UsuarioProjetoDTO user : response.getBody()) {
@@ -271,7 +265,7 @@ class UsuarioControllerTest {
     ResponseEntity<Object> response =
         testRestTemplate.getForEntity("/api/usuarios/professores", Object.class);
 
-    assertEquals(403, response.getStatusCode().value());
+    assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatusCode().value());
   }
 
   @Test
@@ -331,7 +325,6 @@ class UsuarioControllerTest {
     updateRequest.setNome("Nome Atualizado");
     updateRequest.setDepartamentoId(1L);
 
-    // Update profile
     ResponseEntity<UsuarioLogadoInfoDTO> response =
         testRestTemplate.exchange(
             "/api/usuarios/meu-perfil",
@@ -339,7 +332,6 @@ class UsuarioControllerTest {
             new org.springframework.http.HttpEntity<>(updateRequest),
             UsuarioLogadoInfoDTO.class);
 
-    // Verify response
     assertEquals(200, response.getStatusCode().value());
     assertNotNull(response.getBody());
     assertEquals("Nome Atualizado", response.getBody().getNome());
@@ -360,7 +352,7 @@ class UsuarioControllerTest {
             new org.springframework.http.HttpEntity<>(updateRequest),
             UsuarioLogadoInfoDTO.class);
 
-    assertEquals(HttpStatus.FORBIDDEN.value(), response.getStatusCode().value());
+    assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatusCode().value());
   }
 
   @Test
@@ -432,7 +424,6 @@ class UsuarioControllerTest {
 
   @Test
   void updateMeuPerfil_whenCursoIsNull_shouldNotUpdateCurso() {
-    // Create and authenticate user
     UsuarioAlunoRequestDTO createRequest = createUsuarioAlunoRequestDTO();
     ResponseEntity<RespostaLoginDTO> loginResponse =
         testRestTemplate.postForEntity(API_USERS_ALUNO, createRequest, RespostaLoginDTO.class);
@@ -447,16 +438,13 @@ class UsuarioControllerTest {
               return execution.execute(httpRequest, bytes);
             });
 
-    // Get current profile
     ResponseEntity<UsuarioLogadoInfoDTO> currentProfile =
         testRestTemplate.getForEntity("/api/usuarios/meu-perfil", UsuarioLogadoInfoDTO.class);
 
-    // Set curso to null explicitly
     UsuarioLogadoInfoDTO updateRequest = currentProfile.getBody();
     updateRequest.setNome("Nome Atualizado");
     updateRequest.setCurso(null);
 
-    // Update profile
     ResponseEntity<UsuarioLogadoInfoDTO> response =
         testRestTemplate.exchange(
             "/api/usuarios/meu-perfil",
@@ -464,10 +452,8 @@ class UsuarioControllerTest {
             new org.springframework.http.HttpEntity<>(updateRequest),
             UsuarioLogadoInfoDTO.class);
 
-    // Verify response
     assertEquals(200, response.getStatusCode().value());
     assertEquals("Nome Atualizado", response.getBody().getNome());
-    // Curso should remain unchanged
     assertEquals(currentProfile.getBody().getCurso(), response.getBody().getCurso());
   }
 
@@ -516,14 +502,12 @@ class UsuarioControllerTest {
 
   @Test
   void buscarPorEmail_whenUserExists_receiveUser() {
-    // Create a user first
     UsuarioServidorRequestDTO createRequest = createUsuarioServidorRequestDTO();
     ResponseEntity<RespostaLoginDTO> loginResponse =
         testRestTemplate.postForEntity(API_USERS, createRequest, RespostaLoginDTO.class);
 
     String token = loginResponse.getBody().getToken();
 
-    // Authenticate for subsequent requests
     testRestTemplate
         .getRestTemplate()
         .getInterceptors()
@@ -533,12 +517,10 @@ class UsuarioControllerTest {
               return execution.execute(httpRequest, bytes);
             });
 
-    // Test the endpoint
     ResponseEntity<UsuarioProjetoDTO> response =
         testRestTemplate.getForEntity(
             "/api/usuarios/buscar-email/" + createRequest.getEmail(), UsuarioProjetoDTO.class);
 
-    // Verify response
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertNotNull(response.getBody());
     assertEquals(createRequest.getEmail(), response.getBody().getEmail());
@@ -547,7 +529,6 @@ class UsuarioControllerTest {
 
   @Test
   void buscarPorEmail_whenUserDoesNotExist_receiveNotFound() {
-    // Create a user and authenticate
     UsuarioServidorRequestDTO createRequest = createUsuarioServidorRequestDTO();
     ResponseEntity<RespostaLoginDTO> loginResponse =
         testRestTemplate.postForEntity(API_USERS, createRequest, RespostaLoginDTO.class);
@@ -563,14 +544,12 @@ class UsuarioControllerTest {
               return execution.execute(httpRequest, bytes);
             });
 
-    // Test with non-existent email
     String nonExistentEmail = "nonexistent@example.com";
 
     ResponseEntity<UsuarioProjetoDTO> response =
         testRestTemplate.getForEntity(
             "/api/usuarios/buscar-email/" + nonExistentEmail, UsuarioProjetoDTO.class);
 
-    // Verify response
     assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
   }
 


### PR DESCRIPTION
# Pull Request

## Descrição
<!-- Descreva as mudanças feitas no pull request-->

## Checklist
<!-- Marque itens concluídos com um x (sem espaços ao redor) -->
- [ ] Meu código segue a convenção de código definida no documento
- [ ] Eu revisei o código que estou enviando para o PR
- [ ] Eu adicionei Javadoc em funções públicas de negócio ou comentários em lugares necessários
- [ ] Minhas mudanças não geraram nenhum warning
- [ ] Eu rodei `mvn install` e não gerou erro
- [ ] Cobri o código com teste unitário ou de integração
- [ ] Não quebrei nenhum teste com minhas mudanças

## Instruções de Teste
<!-- Como testar o que foi feito, se houver necessidade. Ex: fazer POST /users com os dados "x": "x" no body -->

## Informação Adicional
<!-- Alguma outra coisa de contexto -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * Implementado um novo tratamento para acessos não autenticados, retornando resposta HTTP 401 (Unauthorized) ao tentar acessar recursos protegidos.

* **Correções de Bugs**
  * Ajustados os testes para validar o retorno correto de status HTTP 401 (Unauthorized) em vez de 403 (Forbidden) para acessos não autenticados.

* **Estilo**
  * Melhorias no formato e padronização de código em testes, sem alterações na lógica ou cobertura dos testes.

* **Atualizações em Templates de Email**
  * Atualizados URLs das imagens nos templates de notificação e OTP para apontar para um domínio mais simples e estável.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->