### PR TITLE
Revert "PEXT-199 refactor: implement search for users by partial email or name"

### DIFF
--- a/src/main/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioController.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioController.java
@@ -241,31 +241,13 @@ public class UsuarioController extends CrudController<Usuario, UsuarioServidorRe
     return ResponseEntity.ok(responseDTO);
   }
 
-  /**
-   * Busca usuários que contenham a string informada parcialmente no email ou nome.
-   *
-   * <p>Realiza busca tanto no campo email quanto no campo nome (case insensitive) e retorna uma
-   * lista única sem duplicatas dos usuários encontrados. A busca é feita por substring, permitindo
-   * correspondências parciais.
-   *
-   * @param email string a ser pesquisada nos campos email e nome dos usuários
-   * @return ResponseEntity contendo lista de UsuarioProjetoDTO com os usuários encontrados, ou
-   *     lista vazia se nenhum usuário corresponder aos critérios de busca
-   */
   @GetMapping("/buscar-email/{email}")
-  public ResponseEntity<List<UsuarioProjetoDTO>> buscarPorEmailOuNomeParcial(
-      @PathVariable String email) {
-    List<Usuario> usuariosEmail = usuarioRepository.findByEmailContaining(email);
-    List<Usuario> usuariosNome = usuarioRepository.findByNomeContainingIgnoreCase(email);
-    Set<Usuario> usuariosUnicos = new HashSet<>();
-    usuariosUnicos.addAll(usuariosEmail);
-    usuariosUnicos.addAll(usuariosNome);
-
-    List<UsuarioProjetoDTO> responseDTO =
-        usuariosUnicos.stream()
-            .map(usuario -> modelMapper.map(usuario, UsuarioProjetoDTO.class))
-            .toList();
-
+  public ResponseEntity<UsuarioProjetoDTO> buscarPorEmail(@PathVariable String email) {
+    Usuario usuario = usuarioRepository.findByEmail(email).orElse(null);
+    if (usuario == null) {
+      return ResponseEntity.notFound().build();
+    }
+    UsuarioProjetoDTO responseDTO = modelMapper.map(usuario, UsuarioProjetoDTO.class);
     return ResponseEntity.ok(responseDTO);
   }
 

--- a/src/main/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioRepository.java
+++ b/src/main/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioRepository.java
@@ -46,20 +46,4 @@ public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
    * @return @return lista de usuários que atendem ao critério; lista vazia se nenhum encontrado
    */
   List<Usuario> findAllByEmailEndingWith(String dominioEmail);
-
-  /**
-   * Busca usuários cujo e-mail contém a substring informada.
-   *
-   * @param emailParcial parte do e-mail a ser pesquisada
-   * @return lista de Optional contendo os usuários encontrados
-   */
-  List<Usuario> findByEmailContaining(String emailParcial);
-
-  /**
-   * Busca usuários cujo nome contém a substring informada (case insensitive).
-   *
-   * @param nomeParcial parte do nome a ser pesquisada
-   * @return lista de Optional contendo os usuários encontrados
-   */
-  List<Usuario> findByNomeContainingIgnoreCase(String nomeParcial);
 }

--- a/src/test/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioControllerTest.java
+++ b/src/test/java/br/edu/utfpr/pb/ext/server/usuario/UsuarioControllerTest.java
@@ -42,7 +42,7 @@ class UsuarioControllerTest {
     ResponseEntity<Object> response =
         testRestTemplate.postForEntity(API_USERS, request, Object.class);
 
-    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(200, response.getStatusCode().value());
   }
 
   @Test
@@ -52,7 +52,7 @@ class UsuarioControllerTest {
     ResponseEntity<RespostaLoginDTO> response =
         testRestTemplate.postForEntity(API_USERS, request, RespostaLoginDTO.class);
 
-    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(200, response.getStatusCode().value());
     assertNotNull(response.getBody());
     assertNotNull(response.getBody().getToken());
     assertTrue(response.getBody().getExpiresIn() > 0);
@@ -66,7 +66,7 @@ class UsuarioControllerTest {
     ResponseEntity<Object> response =
         testRestTemplate.postForEntity(API_USERS, request, Object.class);
 
-    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertEquals(400, response.getStatusCode().value());
   }
 
   @Test
@@ -74,15 +74,10 @@ class UsuarioControllerTest {
     UsuarioServidorRequestDTO request = createUsuarioServidorRequestDTO();
     testRestTemplate.postForEntity(API_USERS, request, Object.class);
 
-    // Criar um novo usuário com mesmo CPF mas dados diferentes
-    UsuarioServidorRequestDTO request2 = createUsuarioServidorRequestDTO();
-    request2.setEmail("outro@utfpr.edu.br");
-    request2.setSiape("7654321");
-
     ResponseEntity<Object> response =
-        testRestTemplate.postForEntity(API_USERS, request2, Object.class);
+        testRestTemplate.postForEntity(API_USERS, request, Object.class);
 
-    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertEquals(400, response.getStatusCode().value());
   }
 
   @Test
@@ -93,7 +88,7 @@ class UsuarioControllerTest {
     ResponseEntity<Object> response =
         testRestTemplate.postForEntity(API_USERS, request, Object.class);
 
-    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertEquals(400, response.getStatusCode().value());
   }
 
   @Test
@@ -101,15 +96,10 @@ class UsuarioControllerTest {
     UsuarioServidorRequestDTO request = createUsuarioServidorRequestDTO();
     testRestTemplate.postForEntity(API_USERS, request, Object.class);
 
-    // Criar um novo usuário com mesmo SIAPE mas dados diferentes
-    UsuarioServidorRequestDTO request2 = createUsuarioServidorRequestDTO();
-    request2.setEmail("outro@utfpr.edu.br");
-    request2.setCpf("12345678901");
-
     ResponseEntity<Object> response =
-        testRestTemplate.postForEntity(API_USERS, request2, Object.class);
+        testRestTemplate.postForEntity(API_USERS, request, Object.class);
 
-    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertEquals(400, response.getStatusCode().value());
   }
 
   @Test
@@ -120,7 +110,7 @@ class UsuarioControllerTest {
     ResponseEntity<Object> response =
         testRestTemplate.postForEntity(API_USERS, request, Object.class);
 
-    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertEquals(400, response.getStatusCode().value());
   }
 
   @Test
@@ -130,7 +120,7 @@ class UsuarioControllerTest {
     ResponseEntity<Object> response =
         testRestTemplate.postForEntity(API_USERS_ALUNO, request, Object.class);
 
-    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(200, response.getStatusCode().value());
   }
 
   @Test
@@ -140,7 +130,7 @@ class UsuarioControllerTest {
     ResponseEntity<RespostaLoginDTO> response =
         testRestTemplate.postForEntity(API_USERS_ALUNO, request, RespostaLoginDTO.class);
 
-    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(200, response.getStatusCode().value());
     assertNotNull(response.getBody());
     assertNotNull(response.getBody().getToken());
     assertTrue(response.getBody().getExpiresIn() > 0);
@@ -152,37 +142,25 @@ class UsuarioControllerTest {
     request.setCpf("invalid-cpf");
     ResponseEntity<Object> response =
         testRestTemplate.postForEntity(API_USERS_ALUNO, request, Object.class);
-    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertEquals(400, response.getStatusCode().value());
   }
 
   @Test
   void postUserAluno_WhenUserCpfAlreadyExists_receiveBadRequest() {
     UsuarioAlunoRequestDTO request = createUsuarioAlunoRequestDTO();
     testRestTemplate.postForEntity(API_USERS_ALUNO, request, Object.class);
-
-    // Criar um novo aluno com mesmo CPF mas dados diferentes
-    UsuarioAlunoRequestDTO request2 = createUsuarioAlunoRequestDTO();
-    request2.setEmail("outro@alunos.utfpr.edu.br");
-    request2.setRegistroAcademico("7654321");
-
     ResponseEntity<Object> response =
-        testRestTemplate.postForEntity(API_USERS_ALUNO, request2, Object.class);
-    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        testRestTemplate.postForEntity(API_USERS_ALUNO, request, Object.class);
+    assertEquals(400, response.getStatusCode().value());
   }
 
   @Test
   void postUserAluno_whenRegistroAcademicoAlreadyExists_receiveBadRequest() {
     UsuarioAlunoRequestDTO request = createUsuarioAlunoRequestDTO();
     testRestTemplate.postForEntity(API_USERS_ALUNO, request, Object.class);
-
-    // Criar um novo aluno com mesmo registro acadêmico mas dados diferentes
-    UsuarioAlunoRequestDTO request2 = createUsuarioAlunoRequestDTO();
-    request2.setEmail("outro@alunos.utfpr.edu.br");
-    request2.setCpf("12345678901");
-
     ResponseEntity<Object> response =
-        testRestTemplate.postForEntity(API_USERS_ALUNO, request2, Object.class);
-    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        testRestTemplate.postForEntity(API_USERS_ALUNO, request, Object.class);
+    assertEquals(400, response.getStatusCode().value());
   }
 
   @Test
@@ -191,7 +169,7 @@ class UsuarioControllerTest {
     request.setEmail("invalid-email");
     ResponseEntity<Object> response =
         testRestTemplate.postForEntity(API_USERS_ALUNO, request, Object.class);
-    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertEquals(400, response.getStatusCode().value());
   }
 
   @Test
@@ -200,7 +178,7 @@ class UsuarioControllerTest {
     ResponseEntity<RespostaLoginDTO> loginResponse =
         testRestTemplate.postForEntity(API_USERS, request, RespostaLoginDTO.class);
 
-    assertEquals(HttpStatus.OK, loginResponse.getStatusCode());
+    assertEquals(200, loginResponse.getStatusCode().value());
     assertNotNull(loginResponse.getBody());
     assertNotNull(loginResponse.getBody().getToken());
 
@@ -218,7 +196,7 @@ class UsuarioControllerTest {
     ResponseEntity<UsuarioLogadoInfoDTO> response =
         testRestTemplate.getForEntity("/api/usuarios/meu-perfil", UsuarioLogadoInfoDTO.class);
 
-    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(200, response.getStatusCode().value());
     assertNotNull(response.getBody());
     assertEquals(request.getEmail(), response.getBody().getEmail());
     assertEquals(request.getNome(), response.getBody().getNome());
@@ -231,7 +209,7 @@ class UsuarioControllerTest {
     ResponseEntity<Object> response =
         testRestTemplate.getForEntity("/api/usuarios/meu-perfil", Object.class);
 
-    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatusCode().value());
   }
 
   @Test
@@ -241,7 +219,7 @@ class UsuarioControllerTest {
     ResponseEntity<Object> response =
         testRestTemplate.getForEntity("/api/usuarios/executores", Object.class);
 
-    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatusCode().value());
   }
 
   @Test
@@ -264,7 +242,7 @@ class UsuarioControllerTest {
     ResponseEntity<UsuarioProjetoDTO[]> response =
         testRestTemplate.getForEntity("/api/usuarios/executores", UsuarioProjetoDTO[].class);
 
-    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(200, response.getStatusCode().value());
     assertNotNull(response.getBody());
     assertEquals(1, response.getBody().length);
 
@@ -287,7 +265,7 @@ class UsuarioControllerTest {
     ResponseEntity<Object> response =
         testRestTemplate.getForEntity("/api/usuarios/professores", Object.class);
 
-    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatusCode().value());
   }
 
   @Test
@@ -310,7 +288,7 @@ class UsuarioControllerTest {
     ResponseEntity<UsuarioProjetoDTO[]> response =
         testRestTemplate.getForEntity("/api/usuarios/professores", UsuarioProjetoDTO[].class);
 
-    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(200, response.getStatusCode().value());
     assertNotNull(response.getBody());
 
     for (UsuarioProjetoDTO user : response.getBody()) {
@@ -354,7 +332,7 @@ class UsuarioControllerTest {
             new org.springframework.http.HttpEntity<>(updateRequest),
             UsuarioLogadoInfoDTO.class);
 
-    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(200, response.getStatusCode().value());
     assertNotNull(response.getBody());
     assertEquals("Nome Atualizado", response.getBody().getNome());
     assertEquals(1L, response.getBody().getDepartamentoId());
@@ -374,7 +352,7 @@ class UsuarioControllerTest {
             new org.springframework.http.HttpEntity<>(updateRequest),
             UsuarioLogadoInfoDTO.class);
 
-    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatusCode().value());
   }
 
   @Test
@@ -404,7 +382,7 @@ class UsuarioControllerTest {
             new org.springframework.http.HttpEntity<>(updateRequest),
             Object.class);
 
-    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertEquals(400, response.getStatusCode().value());
   }
 
   @Test
@@ -439,7 +417,7 @@ class UsuarioControllerTest {
     ResponseEntity<UsuarioLogadoInfoDTO> afterUpdate =
         testRestTemplate.getForEntity("/api/usuarios/meu-perfil", UsuarioLogadoInfoDTO.class);
 
-    assertEquals(HttpStatus.OK, afterUpdate.getStatusCode());
+    assertEquals(200, afterUpdate.getStatusCode().value());
     assertNotNull(afterUpdate.getBody());
     assertEquals("Novo Nome", afterUpdate.getBody().getNome());
   }
@@ -474,7 +452,7 @@ class UsuarioControllerTest {
             new org.springframework.http.HttpEntity<>(updateRequest),
             UsuarioLogadoInfoDTO.class);
 
-    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(200, response.getStatusCode().value());
     assertEquals("Nome Atualizado", response.getBody().getNome());
     assertEquals(currentProfile.getBody().getCurso(), response.getBody().getCurso());
   }
@@ -512,7 +490,7 @@ class UsuarioControllerTest {
             new org.springframework.http.HttpEntity<>(updateRequest),
             UsuarioLogadoInfoDTO.class);
 
-    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(200, response.getStatusCode().value());
     assertEquals("Nome Atualizado", response.getBody().getNome());
     assertNotNull(
         response.getBody().getDepartamentoId(), "Department should not be null after update");
@@ -539,15 +517,14 @@ class UsuarioControllerTest {
               return execution.execute(httpRequest, bytes);
             });
 
-    ResponseEntity<UsuarioProjetoDTO[]> response =
+    ResponseEntity<UsuarioProjetoDTO> response =
         testRestTemplate.getForEntity(
-            "/api/usuarios/buscar-email/" + createRequest.getEmail(), UsuarioProjetoDTO[].class);
+            "/api/usuarios/buscar-email/" + createRequest.getEmail(), UsuarioProjetoDTO.class);
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertNotNull(response.getBody());
-    assertEquals(1, response.getBody().length);
-    assertEquals(createRequest.getEmail(), response.getBody()[0].getEmail());
-    assertEquals(createRequest.getNome(), response.getBody()[0].getNome());
+    assertEquals(createRequest.getEmail(), response.getBody().getEmail());
+    assertEquals(createRequest.getNome(), response.getBody().getNome());
   }
 
   @Test
@@ -569,13 +546,11 @@ class UsuarioControllerTest {
 
     String nonExistentEmail = "nonexistent@example.com";
 
-    ResponseEntity<UsuarioProjetoDTO[]> response =
+    ResponseEntity<UsuarioProjetoDTO> response =
         testRestTemplate.getForEntity(
-            "/api/usuarios/buscar-email/" + nonExistentEmail, UsuarioProjetoDTO[].class);
+            "/api/usuarios/buscar-email/" + nonExistentEmail, UsuarioProjetoDTO.class);
 
-    assertEquals(HttpStatus.OK, response.getStatusCode());
-    assertNotNull(response.getBody());
-    assertEquals(0, response.getBody().length);
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
   }
 
   private UsuarioServidorRequestDTO createUsuarioServidorRequestDTO() {


### PR DESCRIPTION
Reverts Utfprpb-oficina-20251/server#130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * Agora é possível buscar usuários apenas pelo e-mail exato, retornando um único usuário ou erro caso não encontrado.

* **Correções de Testes**
  * Ajustados os testes para refletirem o novo comportamento da busca por e-mail, incluindo verificação de resposta 404 quando o usuário não é encontrado.
  * Melhorada a verificação dos códigos de status HTTP nos testes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->